### PR TITLE
Allow configuration overrides on command-line

### DIFF
--- a/AGI/a2billing.php
+++ b/AGI/a2billing.php
@@ -61,7 +61,22 @@ if ($argc > 1 && ($argv[1] == '--version' || $argv[1] == '-v')) {
 $agi = new AGI();
 
 
-if ($argc > 1 && is_numeric($argv[1]) && $argv[1] >= 0) {
+// awh
+// check for configuration overrides in the first argument which would
+// be in the format  1+use_dnid=0&extracharge_did=12345
+$optconfig = array();
+if ($argc > 1 && strstr($argv[1], "+")) {
+	$idconfig = substr($argv[1], 0, strpos($argv[1],"+"));
+	$configstring = substr($argv[1], strpos($argv[1],"+")+1);
+	foreach (explode("&",$configstring) as $conf) {
+		$var = substr($conf, 0, strpos($conf,"="));
+		$val = substr($conf, strpos($conf,"=")+1);
+		$optconfig[$var]=$val;
+	}
+}
+
+// awh add check if idconfig was already set above
+if (!isset($idconfig) && $argc > 1 && is_numeric($argv[1]) && $argv[1] >= 0) {
 	$idconfig = $argv[1];
 } else {
 	$idconfig = 1;
@@ -98,14 +113,14 @@ if ($argc > 5 && strlen($argv[5]) > 0) {
 }
 
 $A2B = new A2Billing();
-$A2B -> load_conf($agi, NULL, 0, $idconfig);
+// awh -- add optconfig
+$A2B -> load_conf($agi, NULL, 0, $idconfig, $optconfig);
 $A2B -> mode = $mode;
 $A2B -> G_startime = $G_startime;
 
 
 $A2B -> debug( INFO, $agi, __FILE__, __LINE__, "IDCONFIG : $idconfig");
 $A2B -> debug( INFO, $agi, __FILE__, __LINE__, "MODE : $mode");
-
 
 $A2B -> CC_TESTING = isset($A2B -> agiconfig['debugshell']) && $A2B -> agiconfig['debugshell'];
 //$A2B -> CC_TESTING = true;


### PR DESCRIPTION
It can be a bit of a pain to maintain separate agi-conf for only changing one or two variables.  For example, use_dnid should be YES for SIP/IAX clients, but it should be NO if somebody is dialing in to the system from their mobile phone and then specifying the number to dial by the keypad.

This change allows some configuration overrides on the AGI command-line by allowing the user to add them after the configuration number, like so:

exten => 0312345678,3,AGI(a2billing.php,"1+use_dnid=0&extracharge_did=12345")
