### PR TITLE
Promotion Package causes account to go negative

### DIFF
--- a/common/lib/Class.RateEngine.php
+++ b/common/lib/Class.RateEngine.php
@@ -878,6 +878,11 @@ class RateEngine
                 $this->freetimetocall_used = $callduration;
                 $callduration = 0;
             }
+            
+            // Fix for promotion package causing balance to go negative.
+            if ($this ->freetimetocall_used <= $callduration){
+                $callduration = $callduration - $this->freetimetocall_used;
+            }
 
             $cost -= ($callduration / 60) * $rateinitial;
             if ($this->debug_st) echo "1.a cost: $cost\n";


### PR DESCRIPTION
If a customer has $1 balance with a 300 free seconds package offer and dials a destination costing 0.14USD/min ( 60 seconds billing increment), his $callduration calculated by Class.RateEngine.php will be 420 seconds ( 7 minutes ).

So his $cost will be - 3.15 USD. Now when his balance is updated at the end of the call, he will end up with a balance of -2.15 USD. This is wrong.

We need to first subtract the 300 free seconds from $callduration before calculating the cost of the call. So i added the  if statement to do that.
