### PR TITLE
Cast cc_call.destination as CHAR to allow the use of indexes

### DIFF
--- a/admin/Public/A2B_card_info.php
+++ b/admin/Public/A2B_card_info.php
@@ -841,7 +841,7 @@ if (sizeof($refill_result)>0 && $refill_result[0]!=null) {
 }
 
 $call_table = new Table('cc_call,cc_prefix','*');
-$call_clause = "card_id = ".$id." AND cc_call.destination = cc_prefix.prefix";
+$call_clause = "card_id = ".$id." AND CAST(cc_call.destination AS CHAR) = cc_prefix.prefix";
 $call_result = $call_table -> Get_list($DBHandle, $call_clause, 'starttime', 'DESC', NULL, NULL, 10, 0);
 if (sizeof($call_result)>0 && $call_result[0]!=null) {
 ?>


### PR DESCRIPTION
Before:
mysql> explain SELECT \* FROM cc_call,cc_prefix WHERE card_id = 64 AND cc_call.destination = cc_prefix.prefix ORDER BY starttime DESC LIMIT 0,10;
+----+-------------+-----------+------+---------------+------+---------+------+----------+----------------------------------------------+
| id | select_type | table     | type | possible_keys | key  | key_len | ref  | rows     | Extra                                        |
+----+-------------+-----------+------+---------------+------+---------+------+----------+----------------------------------------------+
|  1 | SIMPLE      | cc_call   | ALL  | NULL          | NULL | NULL    | NULL | 17432949 | Using where; Using temporary; Using filesort |
|  1 | SIMPLE      | cc_prefix | ALL  | PRIMARY       | NULL | NULL    | NULL |    17174 | Using where; Using join buffer               |
+----+-------------+-----------+------+---------------+------+---------+------+----------+----------------------------------------------+
2 rows in set (0.01 sec)

After:
mysql> explain SELECT \* FROM cc_call,cc_prefix WHERE card_id = 64 AND cast(cc_call.destination as char) = cc_prefix.prefix ORDER BY starttime DESC LIMIT 0,10;
+----+-------------+-----------+--------+---------------+-----------+---------+------+------+-------------+
| id | select_type | table     | type   | possible_keys | key       | key_len | ref  | rows | Extra       |
+----+-------------+-----------+--------+---------------+-----------+---------+------+------+-------------+
|  1 | SIMPLE      | cc_call   | index  | NULL          | starttime | 4       | NULL |   10 | Using where |
|  1 | SIMPLE      | cc_prefix | eq_ref | PRIMARY       | PRIMARY   | 60      | func |    1 | Using where |
+----+-------------+-----------+--------+---------------+-----------+---------+------+------+-------------+
2 rows in set (0.01 sec)
