### PR TITLE
Proof of concept: failover destination

### DIFF
--- a/AGI/a2billing.php
+++ b/AGI/a2billing.php
@@ -136,7 +136,17 @@ $A2B->debug(DEBUG, $agi, __FILE__, __LINE__, "[INFO : $agi_version]");
 $A2B->get_agi_request_parameter($agi);
 
 if (!$A2B->DbConnect()) {
-    $agi->stream_file('prepaid-final', '#');
+    $failover = isset($A2B->config["failover"]["destination"]) ? $A2B->config["failover"]["destination"] : false;
+    if ($mode == 'standard' && $failover && strpos($failover, "%number%") !== false) {
+        $A2B->agiconfig["logging_level"] = INFO;
+        $A2B->agiconfig["verbosity_level"] = INFO;
+        $A2B->debug(WARN, $agi, __FILE__, __LINE__, "No database connection, using failover!");
+        $dialstr = str_replace("%number%", $A2B->dnid, $failover);
+        $A2B->debug(INFO, $agi, __FILE__, __LINE__, "DIAL $dialstr");
+        $A2B->run_dial($agi, $dialstr);
+    } else {
+        $agi->stream_file('prepaid-final', '#');
+    }
     exit;
 }
 

--- a/common/lib/Class.A2Billing.php
+++ b/common/lib/Class.A2Billing.php
@@ -335,8 +335,13 @@ class A2Billing
     {
         $this->idconfig = $idconfig;
         $config_table = new Table("cc_config", "config_key as cfgkey, config_value as cfgvalue, config_group_title as cfggname, config_valuetype as cfgtype");
-        $this->DbConnect();
-        $config_res = $config_table->Get_list($this->DBHandle, "");
+        $result = $this->DbConnect();
+        if ($result) {
+            $config_res = $config_table->Get_list($this->DBHandle, "");
+        } else {
+            echo "Error: cannot connect to database : load_conf_db";
+            return false;
+        }
         if (!$config_res) {
             echo 'Error : cannot load conf : load_conf_db';
             return false;
@@ -3627,7 +3632,8 @@ class A2Billing
         }
         $this->DBHandle = NewADOConnection($datasource);
         if (!$this->DBHandle) {
-            die("Connection failed");
+            echo "Connection failed";
+            return false;
         }
         if ($this->config['database']['dbtype'] == "mysql") {
             $this->DBHandle->Execute('SET AUTOCOMMIT = 1');


### PR DESCRIPTION
As proposed in issue #119 this allows for a destination to be specified in `a2billing.conf` to be used in case of database failure. Sample entry in config file:

```
[failover]
destination = "SIP/%number%@sip_trunk,60,rL(3600000:61000:30000)"
```

We use A2Billing only for outbound postpaid billing, so this is the only case handled. Probably it doesn't make any sense to try this model for other methods, except maybe inbound DID which could be pointed to a backup extension on the system.

The change that needs testing is that `A2Billing::DbConnect()` has been modified to return `false` in case of failure, instead of dying. This seems like a better way of handling things to me, but there may be other locations in the code where this behaviour is not expected. In the AGI there was already a conditional block looking for a false return (which never would have been reached) that I hooked in to.
