### PR TITLE
Destination is of type int(11)

### DIFF
--- a/DataBase/mysql-5.x/UPDATE-a2billing-v2.2.0-to-v2.3.0.sql
+++ b/DataBase/mysql-5.x/UPDATE-a2billing-v2.2.0-to-v2.3.0.sql
@@ -49,3 +49,6 @@ UPDATE cc_config SET config_value = concat(
 ) WHERE id=103;
 
 -- SELECT * FROM cc_config WHERE id=103;
+
+-- Fix cc_ratecard where destination is not the same type as dialprefix
+ALTER TABLE `cc_ratecard` CHANGE `destination` `destination` CHAR(30) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT ''; 

--- a/DataBase/mysql-5.x/UPDATE-a2billing-v2.2.0-to-v2.3.0.sql
+++ b/DataBase/mysql-5.x/UPDATE-a2billing-v2.2.0-to-v2.3.0.sql
@@ -51,6 +51,4 @@ UPDATE cc_config SET config_value = concat(
 -- SELECT * FROM cc_config WHERE id=103;
 
 -- Fix cc_ratecard where destination is not the same type as dialprefix, also, prefix should not auto_increment
-ALTER TABLE `cc_ratecard` CHANGE `dialprefix` `dialprefix` BIGINT(20) NOT NULL; 
 ALTER TABLE `cc_ratecard` CHANGE `destination` `destination` BIGINT(20) NOT NULL; 
-ALTER TABLE `cc_prefix` CHANGE `prefix` `prefix` BIGINT(20) NOT NULL; 

--- a/DataBase/mysql-5.x/UPDATE-a2billing-v2.2.0-to-v2.3.0.sql
+++ b/DataBase/mysql-5.x/UPDATE-a2billing-v2.2.0-to-v2.3.0.sql
@@ -50,5 +50,7 @@ UPDATE cc_config SET config_value = concat(
 
 -- SELECT * FROM cc_config WHERE id=103;
 
--- Fix cc_ratecard where destination is not the same type as dialprefix
-ALTER TABLE `cc_ratecard` CHANGE `destination` `destination` CHAR(30) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT ''; 
+-- Fix cc_ratecard where destination is not the same type as dialprefix, also, prefix should not auto_increment
+ALTER TABLE `cc_ratecard` CHANGE `dialprefix` `dialprefix` BIGINT(20) NOT NULL; 
+ALTER TABLE `cc_ratecard` CHANGE `destination` `destination` BIGINT(20) NOT NULL; 
+ALTER TABLE `cc_prefix` CHANGE `prefix` `prefix` BIGINT(20) NOT NULL; 


### PR DESCRIPTION
Destination is of type int(11) while dialprefix is of type char(30). This breaks where dialprefix is larger than 2147483647 and the simulator shows the wrong destination.