### PR TITLE
Bug in the function fct_say_rate from Class.A2Billing.php

### DIFF
--- a/common/lib/Class.A2Billing.php
+++ b/common/lib/Class.A2Billing.php
@@ -2196,7 +2196,7 @@ class A2Billing
         else $mycur = $currencies_list[strtoupper($this->currency)][2];
         $credit_cur = $rate / $mycur;
 
-        list($units, $cents) = preg_split('/[.]/', $credit_cur);
+        list($units, $cents) = preg_split('/[.]/', sprintf('%f',$credit_cur));
         if (substr($cents, 2) > 0) $point = substr($cents, 2, 1);
         if (strlen($cents) > 2) $cents = substr($cents, 0, 2);
         if ($units == '') $units = 0;


### PR DESCRIPTION
When the fractional part of the variable '$credit_cur' is multiple of 10 (ex. $credit_cur = 0.80000), the number of cents from rate is said erroneously as being 10 times smaller (rate is said as 8 cents).

Fixed.