### PR TITLE
Don't accept an empty password for a user

### DIFF
--- a/common/lib/Form/Class.FormHandler.inc.php
+++ b/common/lib/Form/Class.FormHandler.inc.php
@@ -722,7 +722,9 @@ class FormHandler
 					$filtered_char = array(" ", "-", "_","(",")","+");
 					$this->_processed[$key]= str_replace($filtered_char, "", $this->_processed[$key]);
 				}
-				if($key=='pwd_encoded')$this->_processed[$key] = hash( 'whirlpool',$this->_processed[$key]);
+				if($key=='pwd_encoded' && !empty($value)) {
+					$this->_processed[$key] = hash("whirlpool", $this->_processed[$key]);
+				}
 			}
 		}
 		return $this->_processed;


### PR DESCRIPTION
This prevents mistaken password changes when editing administrators