### PR TITLE
Fix errors on install-db.sh

### DIFF
--- a/DataBase/mysql-5.x/UPDATE-a2billing-v1.4.0-to-v1.4.1.sql
+++ b/DataBase/mysql-5.x/UPDATE-a2billing-v1.4.0-to-v1.4.1.sql
@@ -118,7 +118,7 @@ Delete from cc_config where config_key='cid_auto_create_card_tariffgroup';
 -- change type in cc_config
 ALTER TABLE cc_config CHANGE config_title config_title VARCHAR( 100 ); 
 ALTER TABLE cc_config CHANGE config_key config_key VARCHAR( 100 ); 
-ALTER TABLE cc_config CHANGE config_value config_value VARCHAR( 100 ); 
+ALTER IGNORE TABLE cc_config CHANGE config_value config_value VARCHAR( 100 );
 ALTER TABLE cc_config CHANGE config_listvalues config_listvalues VARCHAR( 100 ); 
 
 -- Set Qualify at No per default

--- a/DataBase/mysql-5.x/UPDATE-a2billing-v1.6.2-to-v1.7.0.sql
+++ b/DataBase/mysql-5.x/UPDATE-a2billing-v1.6.2-to-v1.7.0.sql
@@ -92,7 +92,7 @@ ALTER TABLE cc_templatemail CHANGE messagehtml messagehtml VARCHAR( 3000 ) CHARA
 
 ALTER TABLE cc_card_group CHANGE description description VARCHAR( 400 ) CHARACTER SET utf8 COLLATE utf8_bin NULL DEFAULT NULL;
 
-ALTER TABLE cc_config CHANGE config_description config_description VARCHAR( 500 ) CHARACTER SET utf8 COLLATE utf8_bin NULL DEFAULT NULL;
+ALTER IGNORE TABLE cc_config CHANGE config_description config_description VARCHAR( 500 ) CHARACTER SET utf8 COLLATE utf8_bin NULL DEFAULT NULL;
 
 
 -- Update Version


### PR DESCRIPTION
When executing install-db.sh script in a machine with MariaDB 10.3 the following errors ocurrs:
```
ERROR 1265 (01000) at line 121: Data truncated for column 'config_value' at row 104
ERROR 1406 (22001) at line 95: Data too long for column 'config_description' at row 165
```
This PR fixes that, addressing also issue #170.